### PR TITLE
[release/v1.1.0] Feat: gtag 및 search engine meta tag 컴포넌트화

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+.husky
+.next
+.cache
+node_modules
+dist
+out
+public
+*.d.ts

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",
     "@types/glob": "^8.1.0",
+    "@types/gtag.js": "^0.0.19",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,11 @@ import { Inter } from "next/font/google";
 import "./styles/globals.css";
 import "dayjs/locale/ko";
 import dayjs from "dayjs";
-import Head from "next/head";
+import MonitoringInitializer from "@/components/MonitoringInitializer";
+import {
+  GoogleSearchEngineMetaTag,
+  NaverSearchEngineMetaTag,
+} from "@/components/SearchEngineMetaTags";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -22,15 +26,12 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <head></head>
-      <meta
-        name="google-site-verification"
-        content="ZcOdjUi6TELxVdMxoqWlQX6m5WvqrKsQlWJORDoJrJw"
-      />
-      <meta
-        name="naver-site-verification"
-        content="0c335a67f7e16e4eca72a7ac70ff775d7341846d"
-      />
-      <body className={inter.className}>{children}</body>
+      <GoogleSearchEngineMetaTag />
+      <NaverSearchEngineMetaTag />
+      <body className={inter.className}>
+        <MonitoringInitializer />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/MonitoringInitializer.tsx
+++ b/src/components/MonitoringInitializer.tsx
@@ -1,0 +1,37 @@
+import { isDevMode } from "@/constants/env.constant";
+import Script from "next/script";
+import React from "react";
+
+function MonitoringInitializer() {
+  const GA_TRACKING_ID = "G-HZ44H7LSZJ";
+
+  return (
+    <>
+      {/* google analytics */}
+      {!isDevMode && (
+        <>
+          <Script
+            strategy="afterInteractive"
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+          />
+          <Script
+            id="gtag-init"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_TRACKING_ID}', {
+                  page_path: window.location.pathname,
+                });
+              `,
+            }}
+          />
+        </>
+      )}
+    </>
+  );
+}
+
+export default MonitoringInitializer;

--- a/src/components/SearchEngineMetaTags.tsx
+++ b/src/components/SearchEngineMetaTags.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export function GoogleSearchEngineMetaTag() {
+  return (
+    <meta
+      name="google-site-verification"
+      content="ZcOdjUi6TELxVdMxoqWlQX6m5WvqrKsQlWJORDoJrJw"
+    />
+  );
+}
+
+export function NaverSearchEngineMetaTag() {
+  return (
+    <meta
+      name="naver-site-verification"
+      content="0c335a67f7e16e4eca72a7ac70ff775d7341846d"
+    />
+  );
+}
+
+export const SearchEngineMetaTags = {
+  GoogleSearchEngineMetaTag,
+  NaverSearchEngineMetaTag,
+};

--- a/src/constants/env.constant.ts
+++ b/src/constants/env.constant.ts
@@ -8,6 +8,8 @@ export type EnvType = "production" | "development";
 export const ENV_TYPE: EnvType = (process?.env?.NEXT_PUBLIC_ENV ??
   ENV.DV) as EnvType;
 
+export const isDevMode = ENV_TYPE === ENV.DV;
+
 export const HOST = {
   [ENV.DV]: "http://localhost:3000",
   [ENV.PR]: "https://huns-log.vercel.app",

--- a/src/libs/types.d.ts
+++ b/src/libs/types.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="gtag.js" />
+
+declare module "gtag.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,6 +293,11 @@
     "@types/minimatch" "^5.1.2"
     "@types/node" "*"
 
+"@types/gtag.js@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.19.tgz#40ebbef85c8b2915df164d16304d3fbdfdaa1a41"
+  integrity sha512-KHoDzrf9rSd0mooKN576PjExpdk/XRrNu4RQnmigsScSTSidwyOUe9kDrHz9UPKjiBrx2QEsSkexbJSgS0j72w==
+
 "@types/hast@^2.0.0":
   version "2.3.10"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.10.tgz#5c9d9e0b304bbb8879b857225c5ebab2d81d7643"


### PR DESCRIPTION
### Trouble Shooting

레퍼런스 블로그는 page router 방식이라서, url이 바뀔 때마다 gtag에 바뀐 url을 적용하는 lib 코드를 별도로 두었으나, app router에서는 router event가 제거되어 별도로 설정을 해주어야 했다.   

하지만, 또다른 레퍼런스(10분만 프로젝트)에 따르면 gtag는 페이지의 변경이 생길 때마다 재적용을 해줄 필요가 없는 것으로 파악되어 일단 전역 layout에 `MonitoringInitializer` 컴포넌트를 별도로 두고 gtag 관련 로직을 분리해 layout에 추가했다.

<br>

### Referenece

- [주 레퍼런스 블로그 - google-analytics](https://bepyan.github.io/blog/nextjs-blog/5-google-analytics)
- [10분만 프로젝트 - gtag 포함 MonitoringInitializer 컴포넌트](https://github.com/depromeet/10mm-client-web/blob/develop/src/components/MonitoringInitializer.tsx)